### PR TITLE
Improve README and add requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
 # HostHoover
-Backup Configs: A Python3 utility that pings every host in a subnet, SSH-pulls their running-configs (via Netmiko), names each file by hostname, and packages them all into a ZIP archive.
+
+HostHoover is a Python 3 utility that collects running configuration files from network devices and archives them.
+
+## Features
+
+- Pings each host in the provided subnet and skips unreachable devices.
+- Connects over SSH using [Netmiko](https://github.com/ktbyers/netmiko).
+- Saves each configuration to a file named after the device hostname.
+- Creates a ZIP archive containing all collected configuration files.
+
+## Requirements
+
+- Python 3.8 or higher
+- `netmiko` Python package
+
+Install the dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+```bash
+python3 hosthoover.py <network_cidr> -u <username> -p <password> [options]
+```
+
+Common options:
+
+- `-d`, `--device-type`  Netmiko device type (default: `cisco_ios`)
+- `-o`, `--output`       Directory to save configs (default: `configs`)
+- `-z`, `--zip-name`     Name of the zip file (default: `configs.zip`)
+- `-c`, `--command`      CLI command to run (default: `show running-config`)
+
+Example:
+
+```bash
+python3 hosthoover.py 192.168.1.0/24 -u admin -p password
+```
+
+The script processes the first 20 hosts in the `/24` network and stores the results in the specified output directory.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+netmiko


### PR DESCRIPTION
## Summary
- document HostHoover usage and prerequisites
- add requirements.txt for Netmiko dependency

## Testing
- `python3 -m py_compile hosthoover.py`


------
https://chatgpt.com/codex/tasks/task_e_684c2fcb4bf083208905863aa2e63cbc