### PR TITLE
Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,6 @@ Common device type names for the `--device-type` option include:
 - `cisco_nxos` - Cisco NX-OS (Nexus) devices
 - `cisco_xr` - Cisco IOS-XR routers
 - `juniper_junos` - Juniper Junos platforms
-=======
-
 
 Refer to the Netmiko documentation for details on each device type and any
 special configuration that may be required.


### PR DESCRIPTION
## Summary
- remove leftover merge markers from README
- tidy up blank lines

## Testing
- `python3 -m py_compile hosthoover.py`


------
https://chatgpt.com/codex/tasks/task_e_684c3ba8a0448320948fd52c1a16f44b